### PR TITLE
Fix/random compliment

### DIFF
--- a/everyBot/cogs/random_compliment/random_compliment.py
+++ b/everyBot/cogs/random_compliment/random_compliment.py
@@ -12,6 +12,7 @@ class RandomCompliment(commands.Cog, name="Random"):
         self.bot = bot
 
     async def _check_active(self, guild_id):
+        """ This is a horrible way to do this """
         try:
             guild_installed_modules = await database.fetch_guild_installed_modules(guild_id)
         except Exception:


### PR DESCRIPTION
The disabling of random_compliment is a really shit way of implementing it... Every time the bot WOULD send a compliment, it first checks the database to check if it's enabled by the guild... Maybe some server caching should be implemented in the future so it's not hitting the db so much, but it works for now.